### PR TITLE
Implement Plaid login and token exchange

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next": "15.5.0",
         "postcss": "^8.5.6",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-plaid-link": "^4.1.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -4285,7 +4286,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4661,7 +4661,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4908,7 +4907,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5218,7 +5216,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5282,8 +5279,20 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-plaid-link": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
+      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "15.5.0",
     "postcss": "^8.5.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-plaid-link": "^4.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,8 +43,7 @@ export default function DashboardPage() {
     }, 5000);
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handlePlaidExit = (err: any, metadata: PlaidLinkOnExitMetadata) => {
+  const handlePlaidExit = (err: unknown, metadata: PlaidLinkOnExitMetadata) => {
     if (err) {
       console.error('Plaid Link error:', err);
     } else {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,14 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth, useLogout } from '@/hooks/useAuth';
+import { usePlaid } from '@/hooks/usePlaid';
+import PlaidLinkButton from '@/components/PlaidLink';
+import ConnectedAccounts from '@/components/ConnectedAccounts';
+import { PlaidLinkOnSuccessMetadata, PlaidLinkOnExitMetadata, PlaidLinkError } from '@/types/plaid';
 
 export default function DashboardPage() {
   const router = useRouter();
   const { user, isLoading, isAuthenticated } = useAuth();
   const logoutMutation = useLogout();
+  const { 
+    items, 
+    hasConnectedAccounts, 
+    refreshItems,
+    removeItem 
+  } = usePlaid();
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
 
   useEffect(() => {
     // Redirect to login if not authenticated and not loading
@@ -19,6 +30,25 @@ export default function DashboardPage() {
 
   const handleLogout = () => {
     logoutMutation.mutate();
+  };
+
+  const handlePlaidSuccess = (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
+    console.log('Bank account connected successfully!', { publicToken, metadata });
+    setShowSuccessMessage(true);
+    refreshItems(); // Refresh the list of connected accounts
+    
+    // Hide success message after 5 seconds
+    setTimeout(() => {
+      setShowSuccessMessage(false);
+    }, 5000);
+  };
+
+  const handlePlaidExit = (error: PlaidLinkError | null, metadata: PlaidLinkOnExitMetadata) => {
+    if (error) {
+      console.error('Plaid Link error:', error);
+    } else {
+      console.log('User exited Plaid Link', metadata);
+    }
   };
 
   if (isLoading) {
@@ -36,8 +66,9 @@ export default function DashboardPage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="max-w-2xl w-full space-y-8">
+    <main className="flex min-h-screen flex-col items-center justify-center p-8">
+      <div className="max-w-4xl w-full space-y-8">
+        {/* User Info Section */}
         <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
           <div className="flex justify-between items-start mb-6">
             <div>
@@ -45,7 +76,7 @@ export default function DashboardPage() {
                 Welcome to your Dashboard
               </h1>
               <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                You are successfully logged in!
+                Manage your account and connected bank accounts
               </p>
             </div>
             <button
@@ -87,6 +118,82 @@ export default function DashboardPage() {
           </div>
         </div>
 
+        {/* Success Message */}
+        {showSuccessMessage && (
+          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <p className="text-sm font-medium text-green-800 dark:text-green-200">
+                  Bank account connected successfully!
+                </p>
+                <p className="mt-1 text-sm text-green-700 dark:text-green-300">
+                  Your bank account has been securely linked to your account.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Bank Accounts Section */}
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <div className="mb-6">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+              Bank Accounts
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Connect your bank accounts to get started with financial tracking
+            </p>
+          </div>
+
+          {/* Connected Accounts */}
+          {hasConnectedAccounts ? (
+            <div className="mb-6">
+              <ConnectedAccounts 
+                items={items} 
+                onRemoveItem={removeItem}
+              />
+            </div>
+          ) : (
+            <div className="mb-6 p-6 bg-gray-50 dark:bg-gray-900 rounded-lg text-center">
+              <svg 
+                className="mx-auto h-12 w-12 text-gray-400 mb-3" 
+                fill="none" 
+                viewBox="0 0 24 24" 
+                stroke="currentColor"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" 
+                />
+              </svg>
+              <p className="text-gray-600 dark:text-gray-400 mb-1">
+                No bank accounts connected yet
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-500">
+                Connect your first bank account to start tracking your finances
+              </p>
+            </div>
+          )}
+
+          {/* Connect Bank Account Button */}
+          <div className="flex justify-center">
+            <PlaidLinkButton
+              onSuccess={handlePlaidSuccess}
+              onExit={handlePlaidExit}
+              buttonText={hasConnectedAccounts ? "Connect Another Account" : "Connect Your First Account"}
+              className="w-full sm:w-auto"
+            />
+          </div>
+        </div>
+
+        {/* Navigation */}
         <div className="text-center">
           <Link 
             href="/" 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { useAuth, useLogout } from '@/hooks/useAuth';
 import { usePlaid } from '@/hooks/usePlaid';
 import PlaidLinkButton from '@/components/PlaidLink';
 import ConnectedAccounts from '@/components/ConnectedAccounts';
-import { PlaidLinkOnSuccessMetadata, PlaidLinkOnExitMetadata, PlaidLinkError } from '@/types/plaid';
+import { PlaidLinkOnSuccessMetadata, PlaidLinkOnExitMetadata } from 'react-plaid-link';
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -43,9 +43,10 @@ export default function DashboardPage() {
     }, 5000);
   };
 
-  const handlePlaidExit = (error: PlaidLinkError | null, metadata: PlaidLinkOnExitMetadata) => {
-    if (error) {
-      console.error('Plaid Link error:', error);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handlePlaidExit = (err: any, metadata: PlaidLinkOnExitMetadata) => {
+    if (err) {
+      console.error('Plaid Link error:', err);
     } else {
       console.log('User exited Plaid Link', metadata);
     }

--- a/src/components/ConnectedAccounts.tsx
+++ b/src/components/ConnectedAccounts.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React from 'react';
+import { Item } from '@/services/plaid.service';
+
+interface ConnectedAccountsProps {
+  items: Item[];
+  onRemoveItem?: (itemId: string) => void;
+}
+
+const ConnectedAccounts: React.FC<ConnectedAccountsProps> = ({ 
+  items, 
+  onRemoveItem 
+}) => {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+        Connected Accounts ({items.length})
+      </h3>
+      
+      <div className="grid gap-3">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors"
+          >
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-2">
+                  {/* Bank Icon */}
+                  <svg 
+                    className="h-5 w-5 text-gray-500 dark:text-gray-400" 
+                    fill="none" 
+                    viewBox="0 0 24 24" 
+                    stroke="currentColor"
+                  >
+                    <path 
+                      strokeLinecap="round" 
+                      strokeLinejoin="round" 
+                      strokeWidth={2} 
+                      d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" 
+                    />
+                  </svg>
+                  
+                  {/* Institution Name */}
+                  <h4 className="font-medium text-gray-900 dark:text-white">
+                    {item.institutionName || 'Bank Account'}
+                  </h4>
+                  
+                  {/* Status Badge */}
+                  {item.status && (
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                      item.status === 'active' || item.status === 'good' 
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        : item.status === 'needs_attention' 
+                        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                        : 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200'
+                    }`}>
+                      {item.status}
+                    </span>
+                  )}
+                </div>
+                
+                {/* Item Details */}
+                <div className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
+                  {item.institutionId && (
+                    <p>
+                      <span className="font-medium">Institution ID:</span> {item.institutionId}
+                    </p>
+                  )}
+                  <p className="font-mono text-xs">
+                    <span className="font-sans font-medium">Item ID:</span> {item.id}
+                  </p>
+                </div>
+              </div>
+              
+              {/* Remove Button */}
+              {onRemoveItem && (
+                <button
+                  onClick={() => onRemoveItem(item.id)}
+                  className="ml-4 p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                  title="Remove account"
+                >
+                  <svg 
+                    className="h-5 w-5" 
+                    fill="none" 
+                    viewBox="0 0 24 24" 
+                    stroke="currentColor"
+                  >
+                    <path 
+                      strokeLinecap="round" 
+                      strokeLinejoin="round" 
+                      strokeWidth={2} 
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" 
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      
+      {/* Info Message */}
+      <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+        <div className="flex">
+          <svg 
+            className="h-5 w-5 text-blue-400 mr-2 flex-shrink-0" 
+            fill="currentColor" 
+            viewBox="0 0 20 20"
+          >
+            <path 
+              fillRule="evenodd" 
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" 
+              clipRule="evenodd" 
+            />
+          </svg>
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            Your bank connections are secure and encrypted. Account data is stored safely on our servers.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectedAccounts;

--- a/src/components/PlaidLink.tsx
+++ b/src/components/PlaidLink.tsx
@@ -6,8 +6,7 @@ import PlaidService from '@/services/plaid.service';
 
 interface PlaidLinkButtonProps {
   onSuccess?: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onExit?: (err: any, metadata: PlaidLinkOnExitMetadata) => void;
+  onExit?: (err: unknown, metadata: PlaidLinkOnExitMetadata) => void;
   className?: string;
   buttonText?: string;
   products?: string[];
@@ -87,8 +86,7 @@ export const PlaidLinkButton: React.FC<PlaidLinkButtonProps> = ({
 
   // Handle exit from Plaid Link
   const onExit: PlaidLinkOnExit = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (err: any, metadata: PlaidLinkOnExitMetadata) => {
+    (err: unknown, metadata: PlaidLinkOnExitMetadata) => {
       console.log('Plaid Link exit:', { error: err, metadata });
       
       if (err) {

--- a/src/components/PlaidLink.tsx
+++ b/src/components/PlaidLink.tsx
@@ -6,6 +6,7 @@ import PlaidService from '@/services/plaid.service';
 
 interface PlaidLinkButtonProps {
   onSuccess?: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onExit?: (err: any, metadata: PlaidLinkOnExitMetadata) => void;
   className?: string;
   buttonText?: string;
@@ -86,6 +87,7 @@ export const PlaidLinkButton: React.FC<PlaidLinkButtonProps> = ({
 
   // Handle exit from Plaid Link
   const onExit: PlaidLinkOnExit = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (err: any, metadata: PlaidLinkOnExitMetadata) => {
       console.log('Plaid Link exit:', { error: err, metadata });
       

--- a/src/components/PlaidLink.tsx
+++ b/src/components/PlaidLink.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { usePlaidLink, PlaidLinkOnSuccess, PlaidLinkOnExit, PlaidLinkOnSuccessMetadata, PlaidLinkOnExitMetadata } from 'react-plaid-link';
+import PlaidService from '@/services/plaid.service';
+
+interface PlaidLinkButtonProps {
+  onSuccess?: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => void;
+  onExit?: (err: any, metadata: PlaidLinkOnExitMetadata) => void;
+  className?: string;
+  buttonText?: string;
+  products?: string[];
+  countryCodes?: string[];
+}
+
+export const PlaidLinkButton: React.FC<PlaidLinkButtonProps> = ({
+  onSuccess: onSuccessProp,
+  onExit: onExitProp,
+  className = '',
+  buttonText = 'Connect Bank Account',
+  products = ['transactions', 'accounts'],
+  countryCodes = ['US'],
+}) => {
+  const [linkToken, setLinkToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch link token when component mounts
+  useEffect(() => {
+    const fetchLinkToken = async () => {
+      setIsLoading(true);
+      setError(null);
+      
+      try {
+        const response = await PlaidService.createLinkToken({
+          products,
+          countryCodes,
+        });
+        setLinkToken(response.linkToken);
+      } catch (err) {
+        console.error('Error fetching link token:', err);
+        setError('Failed to initialize bank connection. Please try again.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLinkToken();
+  }, [products, countryCodes]);
+
+  // Handle successful bank connection
+  const onSuccess: PlaidLinkOnSuccess = useCallback(
+    async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
+      console.log('Plaid Link success:', { publicToken, metadata });
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        // Exchange public token for access token
+        const response = await PlaidService.exchangePublicToken(publicToken);
+        
+        // Store the item information with institution name if available
+        const itemToStore = {
+          ...response.item,
+          institutionName: metadata.institution?.name || response.item.institutionName,
+          institutionId: metadata.institution?.institution_id || response.item.institutionId,
+        };
+        PlaidService.storeItemInfo(itemToStore);
+        
+        console.log('Successfully exchanged token:', response);
+        
+        // Call the parent's onSuccess callback if provided
+        if (onSuccessProp) {
+          onSuccessProp(publicToken, metadata);
+        }
+      } catch (err) {
+        console.error('Error exchanging public token:', err);
+        setError('Failed to complete bank connection. Please try again.');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onSuccessProp]
+  );
+
+  // Handle exit from Plaid Link
+  const onExit: PlaidLinkOnExit = useCallback(
+    (err: any, metadata: PlaidLinkOnExitMetadata) => {
+      console.log('Plaid Link exit:', { error: err, metadata });
+      
+      if (err) {
+        // User encountered an error
+        console.error('Plaid Link error:', err);
+      }
+      
+      // Call the parent's onExit callback if provided
+      if (onExitProp) {
+        onExitProp(err, metadata);
+      }
+    },
+    [onExitProp]
+  );
+
+  // Configure Plaid Link
+  const config = {
+    token: linkToken,
+    onSuccess,
+    onExit,
+  };
+
+  const { open, ready } = usePlaidLink(config);
+
+  const handleClick = () => {
+    if (ready) {
+      open();
+    }
+  };
+
+  // Show loading state while fetching link token
+  if (isLoading && !linkToken) {
+    return (
+      <button
+        disabled
+        className={`px-6 py-3 bg-gray-300 text-gray-500 font-medium rounded-lg cursor-not-allowed ${className}`}
+      >
+        Initializing...
+      </button>
+    );
+  }
+
+  // Show error state
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <p className="text-red-600 text-sm">{error}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className={`px-6 py-3 bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 transition-colors ${className}`}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={!ready || isLoading}
+      className={`px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed ${className}`}
+    >
+      {isLoading ? 'Processing...' : buttonText}
+    </button>
+  );
+};
+
+export default PlaidLinkButton;

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -25,3 +25,27 @@ export const LOGIN_MUTATION = gql`
     }
   }
 `;
+
+// Plaid mutations
+export const CREATE_LINK_TOKEN_MUTATION = gql`
+  mutation CreateLinkToken($input: CreateLinkTokenInput!) {
+    createLinkToken(input: $input) {
+      linkToken
+      expiration
+    }
+  }
+`;
+
+export const EXCHANGE_PUBLIC_TOKEN_MUTATION = gql`
+  mutation ExchangePublicToken($input: ExchangePublicTokenInput!) {
+    exchangePublicToken(input: $input) {
+      item {
+        id
+        institutionId
+        institutionName
+        status
+      }
+      accountsCreated
+    }
+  }
+`;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,7 +8,7 @@ export const useSignup = () => {
 
   return useMutation({
     mutationFn: (variables: SignupVariables) => authService.signup(variables),
-    onSuccess: (data) => {
+    onSuccess: () => {
       // Invalidate and refetch any user queries
       queryClient.invalidateQueries({ queryKey: ['user'] });
       // Redirect to dashboard
@@ -26,7 +26,7 @@ export const useLogin = () => {
 
   return useMutation({
     mutationFn: (variables: LoginVariables) => authService.login(variables),
-    onSuccess: (data) => {
+    onSuccess: () => {
       // Invalidate and refetch any user queries
       queryClient.invalidateQueries({ queryKey: ['user'] });
       // Redirect to dashboard

--- a/src/hooks/usePlaid.ts
+++ b/src/hooks/usePlaid.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import PlaidService, { Item } from '@/services/plaid.service';
+
+/**
+ * Custom hook for managing Plaid items (connected bank accounts)
+ */
+export const usePlaidItems = () => {
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load items from local storage on mount
+  useEffect(() => {
+    const loadItems = () => {
+      try {
+        const storedItems = PlaidService.getStoredItems();
+        setItems(storedItems);
+      } catch (error) {
+        console.error('Error loading Plaid items:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadItems();
+  }, []);
+
+  // Add a new item
+  const addItem = useCallback((item: Item) => {
+    PlaidService.storeItemInfo(item);
+    setItems(prevItems => [...prevItems, item]);
+  }, []);
+
+  // Remove an item
+  const removeItem = useCallback((itemId: string) => {
+    const updatedItems = items.filter(item => item.id !== itemId);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('plaid_items', JSON.stringify(updatedItems));
+    }
+    setItems(updatedItems);
+  }, [items]);
+
+  // Clear all items
+  const clearItems = useCallback(() => {
+    PlaidService.clearStoredItems();
+    setItems([]);
+  }, []);
+
+  // Refresh items from storage
+  const refreshItems = useCallback(() => {
+    const storedItems = PlaidService.getStoredItems();
+    setItems(storedItems);
+  }, []);
+
+  return {
+    items,
+    isLoading,
+    addItem,
+    removeItem,
+    clearItems,
+    refreshItems,
+    hasConnectedAccounts: items.length > 0,
+  };
+};
+
+/**
+ * Custom hook for managing Plaid Link connection state
+ */
+export const usePlaidConnection = () => {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [lastConnectedItem, setLastConnectedItem] = useState<Item | null>(null);
+
+  const handleConnectionSuccess = useCallback((item: Item) => {
+    setLastConnectedItem(item);
+    setConnectionError(null);
+    setIsConnecting(false);
+  }, []);
+
+  const handleConnectionError = useCallback((error: string) => {
+    setConnectionError(error);
+    setIsConnecting(false);
+  }, []);
+
+  const startConnection = useCallback(() => {
+    setIsConnecting(true);
+    setConnectionError(null);
+  }, []);
+
+  const resetConnection = useCallback(() => {
+    setIsConnecting(false);
+    setConnectionError(null);
+    setLastConnectedItem(null);
+  }, []);
+
+  return {
+    isConnecting,
+    connectionError,
+    lastConnectedItem,
+    handleConnectionSuccess,
+    handleConnectionError,
+    startConnection,
+    resetConnection,
+  };
+};
+
+/**
+ * Combined hook for complete Plaid functionality
+ */
+export const usePlaid = () => {
+  const itemsHook = usePlaidItems();
+  const connectionHook = usePlaidConnection();
+
+  return {
+    ...itemsHook,
+    ...connectionHook,
+  };
+};
+
+export default usePlaid;

--- a/src/services/plaid.service.ts
+++ b/src/services/plaid.service.ts
@@ -32,6 +32,14 @@ export interface ExchangePublicTokenResponse {
   accountsCreated: number;
 }
 
+interface CreateLinkTokenMutationResponse {
+  createLinkToken: LinkTokenResponse;
+}
+
+interface ExchangePublicTokenMutationResponse {
+  exchangePublicToken: ExchangePublicTokenResponse;
+}
+
 export class PlaidService {
   /**
    * Creates a Plaid Link token for initiating the bank connection flow
@@ -46,12 +54,16 @@ export class PlaidService {
         webhookUrl: input.webhookUrl || undefined,
       };
 
-      const { data } = await client.mutate({
+      const { data } = await client.mutate<CreateLinkTokenMutationResponse>({
         mutation: CREATE_LINK_TOKEN_MUTATION,
         variables: { 
           input: defaultInput
         },
       });
+
+      if (!data) {
+        throw new Error('No data returned from createLinkToken mutation');
+      }
 
       return data.createLinkToken;
     } catch (error) {
@@ -65,7 +77,7 @@ export class PlaidService {
    */
   static async exchangePublicToken(publicToken: string): Promise<ExchangePublicTokenResponse> {
     try {
-      const { data } = await client.mutate({
+      const { data } = await client.mutate<ExchangePublicTokenMutationResponse>({
         mutation: EXCHANGE_PUBLIC_TOKEN_MUTATION,
         variables: { 
           input: { 
@@ -73,6 +85,10 @@ export class PlaidService {
           } 
         },
       });
+
+      if (!data) {
+        throw new Error('No data returned from exchangePublicToken mutation');
+      }
 
       return data.exchangePublicToken;
     } catch (error) {

--- a/src/services/plaid.service.ts
+++ b/src/services/plaid.service.ts
@@ -1,0 +1,116 @@
+import client from '@/lib/apollo-client';
+import { 
+  CREATE_LINK_TOKEN_MUTATION, 
+  EXCHANGE_PUBLIC_TOKEN_MUTATION 
+} from '@/graphql/mutations';
+
+export interface CreateLinkTokenInput {
+  products?: string[];
+  countryCodes?: string[];
+  language?: string;
+  webhookUrl?: string;
+}
+
+export interface LinkTokenResponse {
+  linkToken: string;
+  expiration: string;
+}
+
+export interface ExchangePublicTokenInput {
+  publicToken: string;
+}
+
+export interface Item {
+  id: string;
+  institutionId?: string;
+  institutionName?: string;
+  status?: string;
+}
+
+export interface ExchangePublicTokenResponse {
+  item: Item;
+  accountsCreated: number;
+}
+
+export class PlaidService {
+  /**
+   * Creates a Plaid Link token for initiating the bank connection flow
+   */
+  static async createLinkToken(input: CreateLinkTokenInput = {}): Promise<LinkTokenResponse> {
+    try {
+      // Set default values if not provided
+      const defaultInput = {
+        products: input.products || ['transactions', 'accounts'],
+        countryCodes: input.countryCodes || ['US'],
+        language: input.language || 'en',
+        webhookUrl: input.webhookUrl || undefined,
+      };
+
+      const { data } = await client.mutate({
+        mutation: CREATE_LINK_TOKEN_MUTATION,
+        variables: { 
+          input: defaultInput
+        },
+      });
+
+      return data.createLinkToken;
+    } catch (error) {
+      console.error('Error creating link token:', error);
+      throw new Error('Failed to create Plaid link token');
+    }
+  }
+
+  /**
+   * Exchanges a public token for an access token after successful bank connection
+   */
+  static async exchangePublicToken(publicToken: string): Promise<ExchangePublicTokenResponse> {
+    try {
+      const { data } = await client.mutate({
+        mutation: EXCHANGE_PUBLIC_TOKEN_MUTATION,
+        variables: { 
+          input: { 
+            publicToken 
+          } 
+        },
+      });
+
+      return data.exchangePublicToken;
+    } catch (error) {
+      console.error('Error exchanging public token:', error);
+      throw new Error('Failed to exchange public token');
+    }
+  }
+
+  /**
+   * Stores the Plaid item information in local storage
+   */
+  static storeItemInfo(item: Item): void {
+    if (typeof window !== 'undefined') {
+      const existingItems = this.getStoredItems();
+      const updatedItems = [...existingItems, item];
+      localStorage.setItem('plaid_items', JSON.stringify(updatedItems));
+    }
+  }
+
+  /**
+   * Retrieves stored Plaid items from local storage
+   */
+  static getStoredItems(): Item[] {
+    if (typeof window !== 'undefined') {
+      const storedItems = localStorage.getItem('plaid_items');
+      return storedItems ? JSON.parse(storedItems) : [];
+    }
+    return [];
+  }
+
+  /**
+   * Clears all stored Plaid items
+   */
+  static clearStoredItems(): void {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('plaid_items');
+    }
+  }
+}
+
+export default PlaidService;

--- a/src/types/plaid.ts
+++ b/src/types/plaid.ts
@@ -1,0 +1,33 @@
+// Plaid Link metadata types
+export interface PlaidLinkOnSuccessMetadata {
+  institution?: {
+    name: string;
+    institution_id: string;
+  };
+  accounts: Array<{
+    id: string;
+    name: string;
+    type: string;
+    subtype: string;
+    mask: string;
+  }>;
+  link_session_id: string;
+  transfer_status?: string;
+}
+
+export interface PlaidLinkOnExitMetadata {
+  status?: string;
+  institution?: {
+    name: string;
+    institution_id: string;
+  };
+  link_session_id: string;
+  request_id: string;
+}
+
+export interface PlaidLinkError {
+  error_type: string;
+  error_code: string;
+  error_message: string;
+  display_message: string | null;
+}


### PR DESCRIPTION
Implement Plaid bank account connection and token exchange on the frontend.

This PR integrates the Plaid Link flow, allowing users to connect their bank accounts. It utilizes `react-plaid-link` to initiate the connection, fetches a `link_token` from the backend, and then exchanges the resulting `public_token` via a backend mutation. Connected account information is stored locally and displayed on the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-b17e0343-e631-490d-a9d4-ae74345c7384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b17e0343-e631-490d-a9d4-ae74345c7384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

